### PR TITLE
[FEAT] FileManager의 _read_whole_contents_nand_txt, read_nand_txt 등 추가

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -7,37 +7,6 @@ OUT_FILE_PATH = "ssd_output.txt"
 
 class FileManager:
     def _read_whole_contents_nand_txt(self):
-        pass
-    def read_nand_txt(self, lba):
-        pass
-
-    def write_nand_txt(self, lba, data):
-        pass
-
-    def write_output_txt(self, contents: str):
-        pass
-
-
-class SSD:
-    def __init__(self, file_manager):
-        if not os.path.exists(FILE_PATH):
-            with open(FILE_PATH, "w") as f:
-                for i in range(100):
-                    f.write(f"{i}\t0x00000000\n")
-        self.file_manager = file_manager
-
-    def read(self, LBA):
-        if LBA < 0 or LBA > 99:
-            self.write_output_file("ERROR")
-            return
-
-        data_list = self.file_to_dict()
-        if data_list == "":
-            self.write_output_file("ERROR")
-        self.dict_to_file(data_list)
-        self.write_output_file(data_list[LBA])
-
-    def file_to_dict(self):
         result = {}
         with open(FILE_PATH, "r") as f:
             for line in f:
@@ -51,14 +20,36 @@ class SSD:
                     result[key] = value
         return result
 
+    def read_nand_txt(self, lba):
+        data_list = self._read_whole_contents_nand_txt()
+        if lba < 0 or LBA > lba or data_list == "":
+            return "ERROR"
+        return data_list[lba]
+
+    def write_nand_txt(self, lba, data):
+        pass
+
+    def write_output_txt(self, contents: str):
+        with open(OUT_FILE_PATH, "w") as f:
+            f.write(contents)
+
+
+class SSD:
+    def __init__(self, file_manager):
+        if not os.path.exists(FILE_PATH):
+            with open(FILE_PATH, "w") as f:
+                for i in range(100):
+                    f.write(f"{i}\t0x00000000\n")
+        self.file_manager = file_manager
+
+    def read(self, LBA):
+        read_value = self.file_manager.read_nand_txt(LBA)
+        self.file_manager.write_output_txt(read_value)
+
     def dict_to_file(self, data):
         with open(FILE_PATH, "w") as f:
             for key, value in data.items():
                 f.write(f"{key}\t{value}\n")
-
-    def write_output_file(self, str):
-        with open(OUT_FILE_PATH, "w") as f:
-            f.write(str)
 
     def write(self, LBA, data):
         if LBA < 0 or LBA > 99:
@@ -82,7 +73,7 @@ if __name__ == "__main__":
         print("The index should be an integer among 0 ~ 99")
         sys.exit(1)
 
-    ssd = SSD()
+    ssd = SSD(FileManager())
     mode = sys.argv[1]
     LBA = int(sys.argv[2])
     if mode == "W" and len(sys.argv) == 4:

--- a/ssd.py
+++ b/ssd.py
@@ -22,9 +22,7 @@ class FileManager:
 
     def read_nand_txt(self, lba):
         data_list = self._read_whole_contents_nand_txt()
-        if lba < 0 or LBA > lba or data_list == "":
-            return "ERROR"
-        return data_list[lba]
+        return data_list.get(lba, "")
 
     def write_nand_txt(self, lba, data):
         pass
@@ -43,8 +41,14 @@ class SSD:
         self.file_manager = file_manager
 
     def read(self, LBA):
+        if LBA < 0 or LBA > 99:
+            self.file_manager.write_output_file("ERROR")
+            return
         read_value = self.file_manager.read_nand_txt(LBA)
-        self.file_manager.write_output_txt(read_value)
+        if read_value == "":
+            self.file_manager.write_output_txt("ERROR")
+        else:
+            self.file_manager.write_output_txt(read_value)
 
     def dict_to_file(self, data):
         with open(FILE_PATH, "w") as f:

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -1,6 +1,5 @@
 import pytest
 from pytest_mock import MockerFixture
-
 from ssd import SSD, FileManager
 import re
 
@@ -14,11 +13,10 @@ def test_write_and_read(mocker: MockerFixture):
     ssd.write(lba, expected)
     ssd.read(lba)
 
-    mock_file_manager._read_nand_txt.assert_called()
-    mock_file_manager.read_nand.assert_called_once()
-    mock_file_manager.write_nand.assert_called_once()
-    mock_file_manager.write_output.assert_called_once()
-
+    mock_file_manager._read_whole_contents_nand_txt.assert_called()
+    mock_file_manager.read_nand_txt.assert_called_once()
+    mock_file_manager.write_nand_txt.assert_called_once()
+    mock_file_manager.write_output_txt.assert_called()
 
 def test_read_ssd_nand_txt_file_called_by_read(mocker: MockerFixture):
     mock_file_manager = mocker.Mock()
@@ -27,9 +25,8 @@ def test_read_ssd_nand_txt_file_called_by_read(mocker: MockerFixture):
     read_idx = 0
     ssd.read(read_idx)
 
-    mock_file_manager._read_nand_txt.assert_called()
-    mock_file_manager.read_nand.assert_called_once()
-    mock_file_manager.write_output.assert_called_once()
+    mock_file_manager.read_nand_txt.assert_called_once()
+    mock_file_manager.write_output_txt.assert_called_once()
 
 
 def test_read_ssd_nand_txt_file_called_by_write(mocker: MockerFixture):

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -13,7 +13,6 @@ def test_write_and_read(mocker: MockerFixture):
     ssd.write(lba, expected)
     ssd.read(lba)
 
-    mock_file_manager._read_whole_contents_nand_txt.assert_called()
     mock_file_manager.read_nand_txt.assert_called_once()
     mock_file_manager.write_nand_txt.assert_called_once()
     mock_file_manager.write_output_txt.assert_called()


### PR DESCRIPTION
FileManager의 _read_whole_contents_nand_txt, read_nand_txt, write_output_txt 구현. ssd.read를 수정. test_ssd의 테스트 함수 중 FileManager의 함수 이름을 잘못 쓴 것과 mock -> mocker로 수정