### PR TITLE
[REFACTOR] test함수에서 mock 객체를 fixture로 두고 공통으로 사용하도록 변경.

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -4,10 +4,14 @@ import sys
 from constant import FILENAME, FILENAME_OUT
 
 
-
 class FileManager:
-    def _read_whole_contents_nand_txt(self) -> dict[int, str]:
+    def init_nand_txt(self):
+        if not os.path.exists(FILENAME):
+            with open(FILENAME, "w") as f:
+                for i in range(100):
+                    f.write(f"{i}\t0x00000000\n")
 
+    def _read_whole_contents_nand_txt(self) -> dict[int, str]:
         result = {}
         with open(FILENAME, "r") as f:
             for line in f:
@@ -21,7 +25,7 @@ class FileManager:
         return result
 
     def _save_to_nand_file(self, data) -> None:
-        with open(FILE_PATH, "w") as f:
+        with open(FILENAME, "w") as f:
             for key, value in data.items():
                 f.write(f"{key}\t{value}\n")
 
@@ -39,17 +43,14 @@ class FileManager:
         return True
 
     def write_output_txt(self, contents: str):
-        with open(OUT_FILE_PATH, "w") as f:
+        with open(FILENAME_OUT, "w") as f:
             f.write(contents)
 
 
 class SSD:
     def __init__(self, file_manager):
-        if not os.path.exists(FILE_PATH):
-            with open(FILE_PATH, "w") as f:
-                for i in range(100):
-                    f.write(f"{i}\t0x00000000\n")
         self.file_manager = file_manager
+        self.file_manager.init_nand_txt()
 
     def read(self, LBA):
         if LBA < 0 or LBA > 99:

--- a/ssd.py
+++ b/ssd.py
@@ -14,14 +14,13 @@ class FileManager:
 
     def init_nand_txt(self):
         if not os.path.exists(FILENAME):
-            with open(FILENAME, "w") as f:
-                for i in range(100):
-                    f.write(f"{i}\t0x00000000\n")
+            with self.filename_lock:
+                with open(FILENAME, "w") as f:
+                    for i in range(100):
+                        f.write(f"{i}\t0x00000000\n")
 
     def _read_whole_contents_nand_txt(self) -> dict[int, str]:
-
         result = {}
-
         with self.filename_lock:
             with open(FILENAME, "r") as f:
                 for line in f:

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -4,75 +4,64 @@ from pytest_mock import MockerFixture
 from ssd import SSD, FileManager
 
 
-def test_write_and_read(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock()
-    ssd = SSD(mock_file_manager)
+@pytest.fixture
+def ssd(mocker):
+    file_manager = mocker.Mock()
+    ssd = SSD(file_manager)
+    return ssd
 
+
+def test_write_and_read(ssd):
     lba = 0
     expected = "0x12345678"
     ssd.write(lba, expected)
     ssd.read(lba)
 
-    mock_file_manager.read_nand_txt.assert_called_once()
-    mock_file_manager.write_nand_txt.assert_called_once()
-    mock_file_manager.write_output_txt.assert_called()
+    ssd.file_manager.read_nand_txt.assert_called_once()
+    ssd.file_manager.write_nand_txt.assert_called_once()
+    ssd.file_manager.write_output_txt.assert_called()
 
-def test_read_ssd_nand_txt_file_called_by_read(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock()
-    ssd = SSD(mock_file_manager)
 
+def test_read_ssd_nand_txt_file_called_by_read(ssd):
     read_idx = 0
     ssd.read(read_idx)
 
-    mock_file_manager.read_nand_txt.assert_called_once()
-    mock_file_manager.write_output_txt.assert_called_once()
+    ssd.file_manager.read_nand_txt.assert_called_once()
+    ssd.file_manager.write_output_txt.assert_called_once()
 
 
-def test_read_ssd_nand_txt_file_called_by_write(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock(spec=FileManager)
-    ssd = SSD(mock_file_manager)
-
+def test_read_ssd_nand_txt_file_called_by_write(ssd):
     write_idx = 0
     write_contents = "0x00001111"
     ssd.write(write_idx, write_contents)
 
-    mock_file_manager.write_nand_txt.assert_called()
+    ssd.file_manager.write_nand_txt.assert_called()
 
 
-def test_read_method_record_ssd_output_txt(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock(spec=FileManager)
-    ssd = SSD(mock_file_manager)
-
+def test_read_method_record_ssd_output_txt(ssd):
     read_idx = 0
     ssd.read(read_idx)
 
-    mock_file_manager.read_nand_txt.assert_called()
-    mock_file_manager.write_output_txt.assert_called()
+    ssd.file_manager.read_nand_txt.assert_called()
+    ssd.file_manager.write_output_txt.assert_called()
 
 
-def test_write_ssd(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock(spec=FileManager)
-    ssd = SSD(mock_file_manager)
+def test_write_ssd(ssd):
     loc = 3
     ssd.write(loc, "0xFFFFFFFF")
 
-    mock_file_manager.write_nand_txt.assert_called()
+    ssd.file_manager.write_nand_txt.assert_called()
 
 
-def test_write_check_file(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock(spec=FileManager)
-    ssd = SSD(mock_file_manager)
+def test_write_check_file(ssd):
     loc = 11
     ssd.write(loc, "0x1298CDEF")
 
-    mock_file_manager.write_nand_txt.assert_called()
+    ssd.file_manager.write_nand_txt.assert_called()
 
 
-def test_out_of_index_error(mocker: MockerFixture):
-    mock_file_manager = mocker.Mock(spec=FileManager)
-    ssd = SSD(mock_file_manager)
+def test_out_of_index_error(ssd):
     loc = 120
     ssd.write(loc, "0x1298CDEF")
 
-    mock_file_manager.write_nand_txt.assert_not_called()
-    
+    ssd.file_manager.write_nand_txt.assert_not_called()

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -58,9 +58,3 @@ def test_write_check_file(ssd):
 
     ssd.file_manager.write_nand_txt.assert_called()
 
-
-def test_out_of_index_error(ssd):
-    lba = 120
-    ssd.write(lba, "0x1298CDEF")
-
-    ssd.file_manager.write_nand_txt.assert_not_called()


### PR DESCRIPTION
[REFACTOR] 
1. test함수에서 mock 객체를 fixture로 두고 공통으로 사용하도록 변경.
2. FileManager에서 ssd_nand.txt 파일 생성하도록 변경.