### PR TITLE
[REFACTOR] logger refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 **/__pycache__/
 ssd_nand.txt
 ssd_output.txt
+*.log
+*.zip

--- a/constant.py
+++ b/constant.py
@@ -20,6 +20,11 @@ FILENAME_LOCK = "ssd_nand.lock"
 FILENAME_OUT_LOCK = "ssd_output.lock"
 FILENAME_MAIN_SSD = "ssd.py"
 
+LOG_FILE_MAX_SIZE = 10 * 1024
+LOG_FILE_NAME = "latest.log"
+LOG_METHOD_NAME_WIDTH = 30
+PAST_LOG_FILE_FORMAT = "until_%y%m%d_%Hh_%Mm_%Ss.zip"
+
 MESSAGE_DONE = "DONE"
 MESSAGE_ERROR = "ERROR"
 MESSAGE_FAIL = "FAIL"

--- a/logger.py
+++ b/logger.py
@@ -1,13 +1,12 @@
 import os
 from datetime import datetime
+from constant import LOG_FILE_MAX_SIZE, LOG_FILE_NAME, PAST_LOG_FILE_FORMAT, LOG_METHOD_NAME_WIDTH
 
 
 class Logger:
-    MAX_SIZE = 10 * 1024
-
     def __init__(self, log_dir="."):
         self.log_dir = log_dir
-        self.latest_log = os.path.join(log_dir, "latest.log")
+        self.latest_log = os.path.join(log_dir, LOG_FILE_NAME)
         if not os.path.exists(self.latest_log):
             with open(self.latest_log, "w"):
                 pass
@@ -18,13 +17,13 @@ class Logger:
 
     def _format_log(self, method_name, message):
         timestamp_str, _ = self._get_timestamp()
-        method_name_padded = method_name.ljust(20)
+        method_name_padded = method_name.ljust(LOG_METHOD_NAME_WIDTH)
         return f"[{timestamp_str}] {method_name_padded}: {message}\n"
 
     def _rollover_if_needed(self):
-        if os.path.getsize(self.latest_log) > self.MAX_SIZE:
+        if os.path.getsize(self.latest_log) > LOG_FILE_MAX_SIZE:
             _, now = self._get_timestamp()
-            new_name = now.strftime("until_%y%m%d_%Hh_%Mm_%Ss.log")
+            new_name = now.strftime(PAST_LOG_FILE_FORMAT)
             new_path = os.path.join(self.log_dir, new_name)
             os.rename(self.latest_log, new_path)
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -2,58 +2,62 @@ import pytest
 from unittest.mock import patch, mock_open
 from logger import Logger
 from datetime import datetime
+from constant import LOG_FILE_MAX_SIZE, LOG_FILE_NAME, LOG_METHOD_NAME_WIDTH
+
 
 @pytest.fixture
 def fixed_datetime():
     return "24.07.16 12:34", datetime(2024, 7, 16, 12, 34, 56)
 
 
+@pytest.fixture
+def logger():
+    return Logger(log_dir=".")
+
+
+@pytest.fixture
+def test_case_for_print():
+    return {"method_name": "Shell.run",
+            "message": "hello",
+            "expected_line": f"[24.07.16 12:34] {"Shell.run".ljust(LOG_METHOD_NAME_WIDTH)}: hello\n"}
+
+
 def test_logger_init_creates_log_file():
     with patch("os.path.exists", return_value=False), patch("builtins.open", mock_open()) as m_open:
         Logger(log_dir=".")
-        m_open.assert_called_once_with(".\\latest.log", "w")
+        m_open.assert_called_once_with(f".\\{LOG_FILE_NAME}", "w")
 
 
-def test_format_log_output(fixed_datetime):
-    logger = Logger(log_dir=".")
+def test_format_log_output(fixed_datetime, logger, test_case_for_print):
     with patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])):
-        result = logger._format_log("Shell.run", "hello")
-        assert result == "[24.07.16 12:34] Shell.run           : hello\n"
+        result = logger._format_log(test_case_for_print["method_name"], test_case_for_print["message"])
+        assert result == test_case_for_print["expected_line"]
 
 
-def test_print_writes_log_line(fixed_datetime):
-    logger = Logger(log_dir=".")
+def test_print_writes_log_line(fixed_datetime, logger, test_case_for_print):
     mock_file = mock_open()
 
     with patch("os.path.getsize", return_value=0), \
-         patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])), \
-         patch("builtins.open", mock_file):
+            patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])), \
+            patch("builtins.open", mock_file):
+        logger.print(test_case_for_print["method_name"], test_case_for_print["message"])
 
-        logger.print("Shell.run", "hello")
-
-        expected_line = "[24.07.16 12:34] Shell.run           : hello\n"
-        mock_file().write.assert_called_once_with(expected_line)
+        mock_file().write.assert_called_once_with(test_case_for_print["expected_line"])
 
 
-def test_rollover_happens_when_log_exceeds_size(fixed_datetime):
-    logger = Logger(log_dir=".")
-
-    with patch("os.path.getsize", return_value=Logger.MAX_SIZE + 1), \
-         patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])), \
-         patch("os.rename") as mock_rename, \
-         patch("builtins.open", mock_open()):
-
+def test_rollover_happens_when_log_exceeds_size(fixed_datetime, logger):
+    with patch("os.path.getsize", return_value=LOG_FILE_MAX_SIZE + 1), \
+            patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])), \
+            patch("os.rename") as mock_rename, \
+            patch("builtins.open", mock_open()):
         logger._rollover_if_needed()
 
-        expected_new_log = ".\\until_240716_12h_34m_56s.log"
-        mock_rename.assert_called_once_with(".\\latest.log", expected_new_log)
+        expected_new_log = ".\\until_240716_12h_34m_56s.zip"
+        mock_rename.assert_called_once_with(f".\\{LOG_FILE_NAME}", expected_new_log)
 
 
-def test_rollover_not_triggered_below_max_size():
-    logger = Logger(log_dir=".")
-
-    with patch("os.path.getsize", return_value=Logger.MAX_SIZE - 100), \
-         patch("os.rename") as mock_rename:
-
+def test_rollover_not_triggered_below_max_size(logger):
+    with patch("os.path.getsize", return_value=LOG_FILE_MAX_SIZE - 100), \
+            patch("os.rename") as mock_rename:
         logger._rollover_if_needed()
         mock_rename.assert_not_called()


### PR DESCRIPTION
. log 나 .zip이 무시되도록 gitignore 추가하기
. log을 .zip로 rename하기
. const는 constant.py로 빼기
. method 길이가 긴 것을 대비하여 method 포함 padding 길이를 20에서 30으로 개선 . test_logger.py의 코드 중복 개선 및 가독성 높이기