### PR TITLE
[FEAT] test shell에 mock test들 추가, test_help 버그 수정

### DIFF
--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -9,6 +9,43 @@ def ssd_py_path(mocker):
     return mocker.patch("shell.FILENAME_MAIN_SSD", new="../ssd.py")
 
 
+@pytest.fixture
+def file_mock(mocker):
+    return mocker.patch('builtins.open', mocker.mock_open(read_data=''))
+
+
+@pytest.fixture
+def shell_mock(mocker):
+    pat = mocker.patch('commands.subprocess.run')
+    mock_result = mocker.Mock(returncode=0)
+    pat.return_value = mock_result
+    return pat
+
+
+def test_read_mock(file_mock, shell_mock):
+    Shell.execute_command(ShellCommandEnum.READ, [0])
+    shell_mock.assert_called_once_with(['python', 'ssd.py', 'R', '0'], text=True)
+    file_mock.assert_called_once_with('ssd_output.txt', 'r')
+
+
+def test_write_mock(file_mock, shell_mock):
+    Shell.execute_command(ShellCommandEnum.WRITE, [3, 0x00000000])
+    shell_mock.assert_called_once_with(['python', 'ssd.py', 'W', '3', 0], text=True)
+    file_mock.assert_called_once_with('ssd_output.txt', 'r')
+
+
+def test_full_read_mock(file_mock, shell_mock):
+    Shell.full_read()
+    shell_mock.assert_called_with(['python', 'ssd.py', 'R', '99'], text=True)
+    file_mock.assert_called_with('ssd_output.txt', 'r')
+
+
+def test_full_write_mock(file_mock, shell_mock):
+    Shell.full_write(3)
+    shell_mock.assert_called_with(['python', 'ssd.py', 'W', '99', 3], text=True)
+    file_mock.assert_called_with('ssd_output.txt', 'r')
+
+
 def test_read(ssd_py_path):
     res = Shell.read(lba=0)
     assert res == "[Read] LBA 00 : 0x00000000"

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -76,10 +76,9 @@ def test_exit(ssd_py_path):
     pass
 
 
-def test_help(capsys):
-    Shell.execute_command(cmd=ShellCommandEnum.HELP, args=[])
-    captured = capsys.readouterr()
-    assert MESSAGE_HELP in captured.out
+def test_help():
+    ret = Shell.execute_command(cmd=ShellCommandEnum.HELP, args=[])
+    assert ret == MESSAGE_HELP
 
 
 def test_find_invalid_command(ssd_py_path):


### PR DESCRIPTION
test shell에서 shell에서 subprocess.run 호출 및 파일 접근 동작 확인 목적 mock test들 추가했습니다.