### PR TITLE
[CHORE] until_ 파일이 두 개가 되면, 둘 중 더 오래된 로그의 확장자를 .log 에서 .zip 으로 변경 

### DIFF
--- a/constant.py
+++ b/constant.py
@@ -24,7 +24,7 @@ FILENAME_MAIN_SSD = "ssd.py"
 LOG_FILE_MAX_SIZE = 10 * 1024
 LOG_FILE_NAME = "latest.log"
 LOG_METHOD_NAME_WIDTH = 30
-PAST_LOG_FILE_FORMAT = "until_%y%m%d_%Hh_%Mm_%Ss.zip"
+PAST_LOG_FILE_FORMAT = "until_%y%m%d_%Hh_%Mm_%Ss.log"
 
 MESSAGE_DONE = "DONE"
 MESSAGE_ERROR = "ERROR"

--- a/logger.py
+++ b/logger.py
@@ -2,6 +2,7 @@ import inspect
 import os
 from datetime import datetime
 from typing import Optional, Tuple
+import glob
 
 from constant import (
     LOG_FILE_MAX_SIZE,
@@ -41,6 +42,18 @@ class Logger:
             os.rename(self.latest_log, new_path)
             with open(self.latest_log, "w"):
                 pass
+
+            self._rename_log_files([new_name, "latest.log"])
+
+
+    def _rename_log_files(self, exclude_files):
+        log_files = glob.glob(os.path.join(self.log_dir, "*.log"))
+        exclude_files_set = set(exclude_files)
+        for log_file in log_files:
+            if os.path.basename(log_file) not in exclude_files_set:
+                new_name = log_file.replace(".log", ".zip")
+                os.rename(log_file, new_name)
+                print(f"Renamed {log_file} to {new_name}")
 
     def print(self, message: str, fn_name: Optional[str] = None) -> None:
         self._rollover_if_needed()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -22,12 +22,6 @@ def test_case_for_print():
             "expected_line": f"[24.07.16 12:34] {"Shell.run".ljust(LOG_METHOD_NAME_WIDTH)}: hello\n"}
 
 
-def test_logger_init_creates_log_file():
-    with patch("os.path.exists", return_value=False), patch("builtins.open", mock_open()) as m_open:
-        Logger(log_dir=".")
-        m_open.assert_called_once_with(f".\\{LOG_FILE_NAME}", "w")
-
-
 def test_format_log_output(fixed_datetime, logger, test_case_for_print):
     with patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])):
         result = logger._format_log(test_case_for_print["method_name"], test_case_for_print["message"])
@@ -40,7 +34,7 @@ def test_print_writes_log_line(fixed_datetime, logger, test_case_for_print):
     with patch("os.path.getsize", return_value=0), \
             patch.object(Logger, "_get_timestamp", return_value=(fixed_datetime[0], fixed_datetime[1])), \
             patch("builtins.open", mock_file):
-        logger.print(test_case_for_print["method_name"], test_case_for_print["message"])
+        logger.print(test_case_for_print["message"], test_case_for_print["method_name"])
 
         mock_file().write.assert_called_once_with(test_case_for_print["expected_line"])
 


### PR DESCRIPTION
(실제 압축하는 과정은 없지만, 압축을 가정)