### PR TITLE
[HOTFIX] fix bug in shell when no command entered

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -303,11 +303,11 @@ class Shell:
     def run(cls) -> None:
         while True:
             cmd, args = cls.shell_parser.parse()
+            if cmd is None:
+                continue
             cls.logging(f"Command: {cmd.name} ({args})")
             if cmd == ShellCommandEnum.EXIT:
                 break
-            if cmd is None:
-                continue
             ret = cls.execute_command(cmd, args)
             if ret is not None:
                 print(ret)


### PR DESCRIPTION
shell run에서 커맨드 입력 안됐을 때 로그 프린트 부분에서 발생하는 버그 수정하였습니다.